### PR TITLE
 Issue #32 - Fixes bug in code for putting bugs into buckets

### DIFF
--- a/src/utils/toDayOfWeek.js
+++ b/src/utils/toDayOfWeek.js
@@ -2,14 +2,17 @@ import moment from 'moment';
 
 // By default it changes the day to Friday
 // We're interested to know the state of bucket by the end of the week
-const toDayOfWeek = (dt = new Date(), dayOfWeek = 5) => {
+const toDayOfWeek = (dt = moment().utc(), dayOfWeek = 5) => {
   let increment = 0;
   // isoWeekDay represents Sunday as 7 instead of 0
   const day = moment(dt).isoWeekday();
   if (day > dayOfWeek) {
     increment = 7;
   }
-  return moment(dt).add(increment, 'days').isoWeekday(dayOfWeek).format('YYYY-MM-DD');
+  return moment(dt)
+    .add(increment, 'days')
+    .isoWeekday(dayOfWeek)
+    .format('YYYY-MM-DD');
 };
 
 export default toDayOfWeek;

--- a/test/utils/toDayOfWeek.test.js
+++ b/test/utils/toDayOfWeek.test.js
@@ -26,5 +26,5 @@ it('Current - To Friday of current week', () => {
   const myTempDate = moment().utc();
   const distance = 5 - myTempDate.day(); // 5 represents Friday
   myTempDate.date(myTempDate.date() + distance);
-  expect(newDate).toBe(myTempDate.toISOString().split('T')[0]);
+  expect(moment(myTempDate.format('YYYY-MM-DD')).isSame(newDate)).toBe(true);
 });

--- a/test/utils/toDayOfWeek.test.js
+++ b/test/utils/toDayOfWeek.test.js
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import toDayOfWeek from '../../src/utils/toDayOfWeek';
 
 it('Monday to Friday', () => {
@@ -22,8 +23,8 @@ it('Sunday to Friday', () => {
 
 it('Current - To Friday of current week', () => {
   const newDate = toDayOfWeek();
-  const myTempDate = new Date();
-  const distance = 5 - myTempDate.getDay(); // 5 represents Friday
-  myTempDate.setDate(myTempDate.getDate() + distance);
-  expect(newDate).toBe((myTempDate).toISOString().split('T')[0]);
+  const myTempDate = moment().utc();
+  const distance = 5 - myTempDate.day(); // 5 represents Friday
+  myTempDate.date(myTempDate.date() + distance);
+  expect(newDate).toBe(myTempDate.toISOString().split('T')[0]);
 });


### PR DESCRIPTION
**Problem:** The Date() API creates a date object with the current UTC time, where as when the same object is passed into moment its converted to the local timezone, so when ever the local time zone has moved to the next day and UTC is behind(or vice-versa), one of the tests fail.

**Fix:** Create date objects using moment instead of the Date() API.

@eperelman please review.