### PR TITLE
Add ldapEmail when navigating in the different tabs

### DIFF
--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -16,13 +16,15 @@ const styles = theme => ({
   },
 });
 
-const Header = ({ classes, selectedTabIndex, handleTabChange }) => (
+const Header = ({
+  classes, selectedTabIndex, handleTabChange, ldapEmail,
+}) => (
   <AppBar position="static">
     <Toolbar className={classes.styledToolbar}>
       <Tabs value={selectedTabIndex} onChange={handleTabChange}>
-        <Tab label="Reportees" component={NavLink} to="reportees" />
+        <Tab label="Reportees" component={NavLink} to={`reportees?ldapEmail=${ldapEmail}`} />
         <Tab label="Teams" component={NavLink} to="teams" />
-        <Tab label="Components" component={NavLink} to="components" />
+        <Tab label="Components" component={NavLink} to={`components?ldapEmail=${ldapEmail}`} />
       </Tabs>
       <CredentialsMenu />
     </Toolbar>
@@ -33,6 +35,7 @@ Header.propTypes = {
   classes: PropTypes.shape({}).isRequired,
   selectedTabIndex: PropTypes.number.isRequired,
   handleTabChange: PropTypes.func.isRequired,
+  ldapEmail: PropTypes.string.isRequired,
 };
 
 export default withStyles(styles)(Header);

--- a/src/views/Main/index.jsx
+++ b/src/views/Main/index.jsx
@@ -28,6 +28,7 @@ const DEFAULT_STATE = {
   selectedTabIndex: 0,
   reporteesMetrics: {},
   componentDetails: undefined,
+  ldapEmail: '',
 };
 
 const PATHNAME_TO_TAB_INDEX = {
@@ -263,6 +264,7 @@ class MainContainer extends Component {
           <Header
             selectedTabIndex={selectedTabIndex}
             handleTabChange={this.handleNavigateAndClear}
+            ldapEmail={ldapEmail}
           />
           <div className={classes.content}>
             {!userSession && <h3>Please sign in</h3>}

--- a/test/components/Header.test.jsx
+++ b/test/components/Header.test.jsx
@@ -10,6 +10,7 @@ it('renders the reportees tab', () => {
         <Header
           selectedTabIndex={0}
           handleTabChange={() => null}
+          ldapEmail="fbar@mozilla.com"
         />
       </Router>
     ))

--- a/test/components/__snapshots__/Header.test.jsx.snap
+++ b/test/components/__snapshots__/Header.test.jsx.snap
@@ -30,7 +30,7 @@ exports[`renders the reportees tab 1`] = `
               aria-current={null}
               aria-selected={true}
               className="MuiButtonBase-root-63 MuiTab-root-51 MuiTab-textColorInherit-53 MuiTab-selected-56"
-              href="/reportees"
+              href="/reportees?ldapEmail=fbar@mozilla.com"
               onBlur={[Function]}
               onClick={[Function]}
               onContextMenu={[Function]}
@@ -104,7 +104,7 @@ exports[`renders the reportees tab 1`] = `
               aria-current={null}
               aria-selected={false}
               className="MuiButtonBase-root-63 MuiTab-root-51 MuiTab-textColorInherit-53"
-              href="/components"
+              href="/components?ldapEmail=fbar@mozilla.com"
               onBlur={[Function]}
               onClick={[Function]}
               onContextMenu={[Function]}


### PR DESCRIPTION
Use case:
 i) go to reportees?ldapEmail=dcamp@mozilla.com
 ii) move to components: the url is .../components (ldapEmail has been removed)
 iii) wait few minutes, the view is refreshed but with my ldapEmail (here cdenizet@mozilla.com) so nothing is displayed.

So the goal of the patch is to add ldapEmail param to the routes to be sure that when refresh will occur then the ldapEmail is always the same.