### PR TITLE
Support Taskcluster OAuth expiry

### DIFF
--- a/src/components/auth/oauth2.js
+++ b/src/components/auth/oauth2.js
@@ -12,36 +12,15 @@ export function redirectUser() {
 // Part 2 - Exchange Oauth code for Taskcluster credentials
 export async function userSessionFromCode(url) {
   // Get Oauth access token
-  const user = await webAuth.code.getToken(url);
+  const token = await webAuth.code.getToken(url);
 
   // Exchange that access token for some Taskcluster credentials
-  const request = user.sign({
+  const request = token.sign({
     method: 'get',
   });
   const resp = await fetch(config.OAuth2Options.credentialsUri, request);
   const payload = await resp.json();
 
   // Finally build a new user session
-  return UserSession.fromCredentials(payload.credentials);
-}
-
-/* eslint-disable consistent-return */
-export async function renew({ userSession }) {
-  if (
-    !userSession
-    || userSession.type !== 'oidc'
-    || userSession.oidcProvider !== 'mozilla-auth0'
-  ) {
-    return;
-  }
-
-  return new Promise((accept, reject) => webAuth.renewAuth({}, (err, authResult) => {
-    if (err) {
-      return reject(err);
-    } if (!authResult) {
-      return reject(new Error('no authResult'));
-    }
-    // TODO: somehow renew ? Not possible i think with Oauth + TC
-    accept();
-  }));
+  return UserSession.fromTaskclusterAuth(token.accessToken, payload);
 }

--- a/src/config.js
+++ b/src/config.js
@@ -14,7 +14,9 @@ const config = {
     redirectUri: PRODUCTION ? 'https://bugzilla-management-dashboard.netlify.app' : 'http://localhost:5000',
     whitelisted: true,
     responseType: 'code',
-    maxExpires: '15 minutes',
+    query: {
+      expires: '2 weeks',
+    },
   },
   productComponentMetrics: 'project/relman/bugzilla-dashboard/product_component_data.json.gz',
   reporteesMetrics: 'project/relman/bugzilla-dashboard/reportee_data.json.gz',

--- a/src/views/ProfileMenu/index.jsx
+++ b/src/views/ProfileMenu/index.jsx
@@ -72,6 +72,10 @@ class ProfileMenu extends React.Component {
             onClose={this.handleClose}
           >
             <MenuItem>{userSession.name}</MenuItem>
+            <MenuItem>
+              <span>Expires in&nbsp;</span>
+              {userSession.expiresIn}
+            </MenuItem>
             <MenuItem onClick={() => context.setUserSession(null)}>Sign out</MenuItem>
           </Menu>
         </div>


### PR DESCRIPTION
We can't refresh the token, but we can at least display the expiry, and invalidate the session cleanly.

![](https://i.imgur.com/UWA9yNN.png)