### PR TITLE
offboard bpitts

### DIFF
--- a/src/static/triageOwners.json
+++ b/src/static/triageOwners.json
@@ -1657,7 +1657,7 @@
             "component": "Operations: Firefox Profiler"
         }
     ],
-    "bpitts@mozilla.com": [
+    "jwhitlock@mozilla.com": [
         {
             "product": "Cloud Services",
             "component": "Operations: Taskcluster"


### PR DESCRIPTION
I wasn't sure who replaces Brian for triage ownership of this component, so I picked `jwhitlock` as he is an admin of taskcluster-security-team, and so would have the ability to triage effectively. Whoever processes this PR should confirm before merging.

@sylvestre Perhaps this list is maintained outside of GitHub and only copied here instead?